### PR TITLE
Fix: Correct image path in Design Observations post

### DIFF
--- a/_posts/2025-06-22-design-observations.md
+++ b/_posts/2025-06-22-design-observations.md
@@ -14,7 +14,7 @@ A browser's "press escape to exit fullscreen" alert works perfectly here. New us
 
 This respects user expertise while keeping helpful guidance.
 
-![Alert Example](/assets/img/alert.png)
+![Alert Example]({{ '/assets/img/alert.png' | relative_url }})
 
 ## User delight via micro animations
 


### PR DESCRIPTION
Updated the image path to use the `relative_url` filter, ensuring it works correctly regardless of the site's baseurl.